### PR TITLE
fixed 'data not saving to local storage' bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,7 +36,7 @@ listContainer.addEventListener("click", function(e){
 
 function saveTask(){
     //store input to the localStorage
-     loacalStorage.setItem("data",listContainer.innerHTML);
+     localStorage.setItem("data",listContainer.innerHTML);
 }
 
 function showTask(){


### PR DESCRIPTION
fixes #1 

I noticed there was a typo when calling `localStorage` in the `saveTask()` method.
You had:
```diff
- loacalStorage.setItem("data",listContainer.innerHTML);
```
instead of:

```diff
+ localStorage.setItem("data",listContainer.innerHTML);
```

Notice the "a" in "local".
